### PR TITLE
Bump metro to 1.0.0 and inline app initializers

### DIFF
--- a/app/src/main/java/dev/jasonpearson/android/App.kt
+++ b/app/src/main/java/dev/jasonpearson/android/App.kt
@@ -24,14 +24,14 @@
 package dev.jasonpearson.android
 
 import android.app.Application
+import dev.jasonpearson.android.debug.setupStrictMode
 import dev.jasonpearson.android.di.AppGraph
-import dev.jasonpearson.android.di.ApplicationModule
 import dev.jasonpearson.android.di.BackgroundAppCoroutineScope
+import dev.jasonpearson.android.logging.Logger
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.createGraphFactory
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-
-private typealias InitializerFunction = () -> Unit
 
 class App : Application() {
 
@@ -41,13 +41,9 @@ class App : Application() {
 
     internal lateinit var appComponent: AppGraph
 
-    @Inject @ApplicationModule.Initializers lateinit var initializers: Set<InitializerFunction>
-
-    @Inject
-    @ApplicationModule.AsyncInitializers
-    lateinit var asyncInitializers: Set<InitializerFunction>
-
     @Inject lateinit var backgroundScope: BackgroundAppCoroutineScope
+
+    @Inject lateinit var logger: Logger
 
     override fun onCreate() {
         super.onCreate()
@@ -55,12 +51,11 @@ class App : Application() {
         appComponent =
             createGraphFactory<AppGraph.Factory>().create(this).apply { inject(this@App) }
 
-        // Run synchronous initializers
-        initializers.forEach { it() }
-
-        // Run async initializers in parallel
         backgroundScope.launch {
-            asyncInitializers.forEach { initializer -> launch { initializer() } }
+            launch { setupStrictMode(logger) }
+            // Pre-initialize Dispatchers.Main off the main thread to avoid disk I/O on first
+            // access.
+            launch { Dispatchers.Main }
         }
     }
 }

--- a/app/src/main/java/dev/jasonpearson/android/debug/StrictModeModule.kt
+++ b/app/src/main/java/dev/jasonpearson/android/debug/StrictModeModule.kt
@@ -27,57 +27,37 @@ import android.os.Build
 import android.os.StrictMode
 import android.os.strictmode.DiskReadViolation
 import android.os.strictmode.UntaggedSocketViolation
-import dev.jasonpearson.android.di.AppScope
-import dev.jasonpearson.android.di.ApplicationModule
 import dev.jasonpearson.android.logging.Logger
 import dev.jasonpearson.android.logging.e
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.IntoSet
-import dev.zacsweers.metro.Provides
 import java.util.concurrent.Executors
 
-private const val TAG = "StrictModeModule"
+private const val TAG = "StrictModeSetup"
 
 /**
- * Contributes StrictMode setup to the async initializers set.
- *
- * StrictMode is configured to detect all violations and log them. Known false positives from
- * Flipper and Chrome Custom Tabs are suppressed.
+ * Configures StrictMode to detect all violations and log them. Known false positives from Flipper
+ * and Chrome Custom Tabs are suppressed.
  */
-@ContributesTo(AppScope::class)
-interface StrictModeModule {
+fun setupStrictMode(logger: Logger) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+    StrictMode.setVmPolicy(
+        StrictMode.VmPolicy.Builder()
+            .detectAll()
+            .penaltyListener(Executors.newSingleThreadExecutor()) { violation ->
+                when {
+                    violation is UntaggedSocketViolation -> {
+                        // Known issue with Flipper - ignore
+                    }
 
-    companion object {
+                    violation is DiskReadViolation &&
+                        violation.stackTraceToString().contains("CustomTabsConnection") -> {
+                        // Known issue with Chrome Custom Tabs - ignore
+                    }
 
-        @ApplicationModule.AsyncInitializers
-        @IntoSet
-        @Provides
-        fun strictModeInit(logger: Logger): () -> Unit = {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                StrictMode.setVmPolicy(
-                    StrictMode.VmPolicy.Builder()
-                        .detectAll()
-                        .penaltyListener(Executors.newSingleThreadExecutor()) { violation ->
-                            when {
-                                violation is UntaggedSocketViolation -> {
-                                    // Known issue with Flipper - ignore
-                                }
-
-                                violation is DiskReadViolation &&
-                                    violation
-                                        .stackTraceToString()
-                                        .contains("CustomTabsConnection") -> {
-                                    // Known issue with Chrome Custom Tabs - ignore
-                                }
-
-                                else -> {
-                                    logger.e(TAG, "StrictMode violation detected", violation)
-                                }
-                            }
-                        }
-                        .build()
-                )
+                    else -> {
+                        logger.e(TAG, "StrictMode violation detected", violation)
+                    }
+                }
             }
-        }
-    }
+            .build()
+    )
 }

--- a/app/src/main/java/dev/jasonpearson/android/di/ApplicationModule.kt
+++ b/app/src/main/java/dev/jasonpearson/android/di/ApplicationModule.kt
@@ -24,20 +24,14 @@
 package dev.jasonpearson.android.di
 
 import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.Qualifier
 import kotlin.annotation.AnnotationRetention.BINARY
 import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 
 @ContributesTo(AppScope::class)
 interface ApplicationModule {
-
-    @Qualifier @Retention(BINARY) annotation class Initializers
-
-    @Qualifier @Retention(BINARY) annotation class AsyncInitializers
 
     @Qualifier @Retention(BINARY) annotation class LazyDelegate
 
@@ -52,35 +46,5 @@ interface ApplicationModule {
         @SingleIn(AppScope::class)
         fun providePresenterScope(backgroundScope: BackgroundAppCoroutineScope): CoroutineScope =
             backgroundScope
-    }
-}
-
-/**
- * Module for app initialization hooks. Provides sets of initializer functions that run at app
- * startup.
- */
-@ContributesTo(AppScope::class)
-interface InitializersModule {
-
-    companion object {
-        /**
-         * Placeholder for synchronous initializers. In a real app, you would contribute actual
-         * initializers here using @IntoSet with @Initializers qualifier.
-         */
-        @ApplicationModule.Initializers
-        @Provides
-        fun provideInitializers(): Set<() -> Unit> = emptySet()
-
-        /**
-         * Pre-initializes Dispatchers.Main off the main thread to avoid disk I/O on first access.
-         * This is contributed to the async initializers set.
-         */
-        @ApplicationModule.AsyncInitializers
-        @IntoSet
-        @Provides
-        fun mainDispatcherInit(): () -> Unit = {
-            // This makes a call to disk, so initialize it off the main thread first... ironically
-            Dispatchers.Main
-        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ test-androidx-espresso = "3.7.0"
 
 navigation = "2.9.8"
 
-metro = "0.13.2"
+metro = "1.0.0"
 
 [plugins]
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "build-gradle-dependencyAnalysis" }


### PR DESCRIPTION
## Summary

Supersedes #391. Metro 1.0.0 with `enableFunctionProviders` (default) rejects `@Provides` returning `() -> Unit`, because parameter-less Kotlin function types are treated as provider types and can't be unique bindings on the graph.

The repo's `@AsyncInitializers Set<() -> Unit>` pattern had only two contributors (StrictMode setup, Dispatchers.Main warm-up). Inlining them into `App.onCreate` is simpler and avoids the Metro restriction.

- `StrictModeModule` becomes a plain top-level `setupStrictMode(logger)` helper.
- Drop the `Initializers` / `AsyncInitializers` qualifiers and the empty `provideInitializers` placeholder.
- `App` injects `Logger` directly and launches both initializers on the background scope.

## Test plan

- [ ] CI: Unit Tests, Android Lint, Build APK, Build Test APK all green (these were the failures on #391)
- [ ] Manual smoke: confirm StrictMode violations still log on a debug build